### PR TITLE
feat: allow user to specify repo path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use dotenv;
 use merit_cli_demo::run;
+use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
-    run().await
+    
+    let repo_path = env::args().nth(1);
+    run(repo_path).await
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use dialoguer::{theme::ColorfulTheme, Select};
+use dialoguer::{theme::ColorfulTheme, Select, Input};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::modes::Mode;
@@ -38,4 +38,13 @@ pub async fn select_mode() -> Result<Mode, Box<dyn Error>> {
         1 => Mode::FileAnalysis,
         _ => Mode::ContributorAnalysis,
     })
+}
+
+pub fn get_repository_path(default: &str) -> Result<String, Box<dyn Error>> {
+    let path: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter repository path")
+        .default(default.into())
+        .allow_empty(true)
+        .interact()?;
+    Ok(if path.is_empty() { ".".to_string() } else { path })
 }


### PR DESCRIPTION
Allow a user to point the CLI tool at an repository on their machine rather than always using the current repo.
<img width="191" alt="image" src="https://github.com/user-attachments/assets/9e0f4d2b-2bb0-4eac-8510-bb265691b497" />
